### PR TITLE
Add RedisLockingStrategy strategy only if Redis is configured

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,8 +2,11 @@
 
 defined('TYPO3_MODE') or die();
 
-(function () {
-    $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
-    $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
+(static function () {
+    // since some environments might not have Redis installed and configured,
+    // we do not want to add RedisLockingStrategy for them
+    if (is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis'])) {
+        $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
+        $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
+    }
 })();
-


### PR DESCRIPTION
At current environments Redis is configured through AdditionalConfiguration file:

if ($redis->select($redisNumber + 9)) {
  $GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis'] = [
    'database' => $redisNumber + 9,
    'hostname' => $redisHost,
    'port' => $redisPort
];

If database can't be selected, configuration won't be added and this should result
with no RedisLockingStrategy strategy added.